### PR TITLE
Test CI against latest Elixir and OTP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -20,7 +22,12 @@ jobs:
           - pair:
               elixir: "1.15.4"
               otp: "26.0"
-            lint: lint
+              version_type: "strict"
+          - pair:
+              elixir: "1.19.x"
+              otp: "29.x"
+              version_type: "loose"
+            lint: true
     steps:
       - uses: actions/checkout@v6
 
@@ -29,7 +36,7 @@ jobs:
         with:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}
-          version-type: "strict"
+          version-type: ${{matrix.pair.version_type}}
 
       - name: Cache deps
         id: cache-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,6 @@ jobs:
           key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ matrix.pair.elixir }}-${{ matrix.pair.otp }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-${{ env.cache-name }}-${{ matrix.pair.elixir }}-${{ matrix.pair.otp }}-
-            ${{ runner.os }}-mix-${{ env.cache-name }}-
-            ${{ runner.os }}-mix-
 
       - name: Clean to rule out incremental build as a source of flakiness
         if: github.run_attempt != '1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,18 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   mix_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
     env:
       MIX_ENV: test
 


### PR DESCRIPTION
## Summary
- add a CI matrix entry for Elixir 1.19.x / OTP 29.x
- keep the minimum supported Elixir 1.15.4 / OTP 26.0 test job
- run linting only on the latest runtime job

## Validation
- mix test